### PR TITLE
Pass through args to Storybook commands

### DIFF
--- a/src/bin/archive-storybook.ts
+++ b/src/bin/archive-storybook.ts
@@ -3,6 +3,9 @@
 import { execFileSync } from 'child_process';
 import { resolve, dirname } from 'path';
 
+// Discard first two entries (exec path and file path)
+const args = process.argv.slice(2);
+
 const configDir = 'node_modules/@chromaui/archive-storybook/config';
 const binPath = resolve(dirname(require.resolve('@storybook/cli/package.json')), './bin/index.js');
-execFileSync(binPath, ['dev', '-c', configDir], { stdio: 'inherit' });
+execFileSync(binPath, ['dev', ...args, '-c', configDir], { stdio: 'inherit' });

--- a/src/bin/build-archive-storybook.ts
+++ b/src/bin/build-archive-storybook.ts
@@ -3,6 +3,9 @@
 import { execFileSync } from 'child_process';
 import { resolve, dirname } from 'path';
 
+// Discard first two entries (exec path and file path)
+const args = process.argv.slice(2);
+
 const configDir = 'node_modules/@chromaui/archive-storybook/config';
 const binPath = resolve(dirname(require.resolve('@storybook/cli/package.json')), './bin/index.js');
-execFileSync(binPath, ['build', '-c', configDir], { stdio: 'inherit' });
+execFileSync(binPath, ['build', ...args, '-c', configDir], { stdio: 'inherit' });


### PR DESCRIPTION
## What Changed

This allows passing arguments (`--debug-webpack`, for example) through to the Storybook commands. 

<!-- Insert a description below. -->

## How to test

* Install the canary version
* Test passing arguments to the `archive-storybook` and `build-archive-storybook` commands
  * `yarn archive-storybook --debug-webpack`, etc

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.11--canary.5.76b56a0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/archive-storybook@0.0.11--canary.5.76b56a0.0
  # or 
  yarn add @chromaui/archive-storybook@0.0.11--canary.5.76b56a0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
