### PR TITLE
Archives are created at subfolder of playwright's results folder

### DIFF
--- a/config/main.js
+++ b/config/main.js
@@ -1,6 +1,6 @@
-const { CHROMATIC_ARCHIVE_LOCATION = 'test-archives/latest' } = process.env;
+const { CHROMATIC_ARCHIVE_LOCATION = 'test-results' } = process.env;
 
-const ARCHIVES_DIR = `../../../../${CHROMATIC_ARCHIVE_LOCATION}`;
+const ARCHIVES_DIR = `../../../../${CHROMATIC_ARCHIVE_LOCATION}/chromatic-archives`;
 
 /** @type { import('@storybook/server-webpack5').StorybookConfig } */
 const config = {


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->

Reflects that we are using playwright's created test results directory as the place to put our archives. This change also handles if the user were to set a custom Playwright output directory for their test results. (`outputDir`) 

**_This needs to release at the same time as the corresponding `test-archiver` [change](https://github.com/chromaui/test-archiver/pull/17)._**

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

1. Blow away the `test-archives` directory in the e2e project you are running this against.
1. Complete steps 5-7 of the [corresponding PR](https://github.com/chromaui/test-archiver/pull/17)
2. Run `CHROMATIC_ARCHIVE_LOCATION=<whatever-location-you-set-in-the-playwright-config> yarn build-archive-storybook`
3. Verify that storybook is built without errors
4. Run `CHROMATIC_ARCHIVE_LOCATION=<whatever-location-you-set-in-the-playwright-config> yarn archive-storybook`
5. Verify that storybook loads and contains all the stories
6. Complete steps 1-3 of the [corresponding PR](https://github.com/chromaui/test-archiver/pull/17)
7. Run `yarn build-archive-storybook` and `yarn archive-storybook`
8. Verify that both succeed without error and the storybook contains all the stories

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
