### PR TITLE
Fix exec to work on Windows

### DIFF
--- a/src/bin/archive-storybook.ts
+++ b/src/bin/archive-storybook.ts
@@ -8,4 +8,4 @@ const args = process.argv.slice(2);
 
 const configDir = 'node_modules/@chromaui/archive-storybook/config';
 const binPath = resolve(dirname(require.resolve('@storybook/cli/package.json')), './bin/index.js');
-execFileSync(binPath, ['dev', ...args, '-c', configDir], { stdio: 'inherit' });
+execFileSync('node', [binPath, 'dev', ...args, '-c', configDir], { stdio: 'inherit' });

--- a/src/bin/build-archive-storybook.ts
+++ b/src/bin/build-archive-storybook.ts
@@ -8,4 +8,4 @@ const args = process.argv.slice(2);
 
 const configDir = 'node_modules/@chromaui/archive-storybook/config';
 const binPath = resolve(dirname(require.resolve('@storybook/cli/package.json')), './bin/index.js');
-execFileSync(binPath, ['build', ...args, '-c', configDir], { stdio: 'inherit' });
+execFileSync('node', [binPath, 'build', ...args, '-c', configDir], { stdio: 'inherit' });


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->
Fix the `execFileSync` to work on Windows. This works in the Windows 11 VM I'm testing with.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Install the canary version (`0.0.14--canary.7fdd613.0`)
* Run `yarn build-archive-storybook` and `yarn archive-storybook` in a project that that resides inside a directory with a space in its name

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
