### PR TITLE
Raise error when archives dir cannot be found

### DIFF
--- a/config/main.js
+++ b/config/main.js
@@ -1,15 +1,14 @@
-const { CHROMATIC_ARCHIVE_LOCATION = 'test-results' } = process.env;
-
-const ARCHIVES_DIR = `../../../../${CHROMATIC_ARCHIVE_LOCATION}/chromatic-archives`;
+const path = require('path');
+const { archivesDir } = require('../dist/filePaths');
 
 /** @type { import('@storybook/server-webpack5').StorybookConfig } */
 const config = {
-  stories: [`${ARCHIVES_DIR}/*.stories.json`],
+  stories: [path.resolve(archivesDir(), '*.stories.json')],
   addons: ['@storybook/addon-essentials', '../dist'],
   framework: {
     name: '@storybook/server-webpack5',
     options: {},
   },
-  staticDirs: [`${ARCHIVES_DIR}/archive`],
+  staticDirs: [path.resolve(archivesDir(), 'archive')],
 };
 module.exports = config;

--- a/src/bin/archive-storybook.ts
+++ b/src/bin/archive-storybook.ts
@@ -2,6 +2,9 @@
 
 import { execFileSync } from 'child_process';
 import { resolve, dirname } from 'path';
+import { checkArchivesDirExists } from '../filePaths';
+
+checkArchivesDirExists();
 
 // Discard first two entries (exec path and file path)
 const args = process.argv.slice(2);

--- a/src/bin/build-archive-storybook.ts
+++ b/src/bin/build-archive-storybook.ts
@@ -2,6 +2,9 @@
 
 import { execFileSync } from 'child_process';
 import { resolve, dirname } from 'path';
+import { checkArchivesDirExists } from '../filePaths';
+
+checkArchivesDirExists();
 
 // Discard first two entries (exec path and file path)
 const args = process.argv.slice(2);

--- a/src/filePaths.ts
+++ b/src/filePaths.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const { CHROMATIC_ARCHIVE_LOCATION = 'test-results' } = process.env;
+
+function rootDir() {
+  return process.cwd();
+}
+
+export function archivesDir() {
+  return path.resolve(rootDir(), CHROMATIC_ARCHIVE_LOCATION, 'chromatic-archives');
+}
+
+export function checkArchivesDirExists() {
+  const dir = archivesDir();
+  if (!fs.existsSync(dir)) {
+    throw new Error(
+      `Chromatic archives directory cannot be found: ${dir}\n\nPlease make sure that you have run your E2E tests, or have set the CHROMATIC_ARCHIVE_LOCATION env var if the output directory for the tests is not in the standard location.`
+    );
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "types": ["jest", "node"],
     "moduleResolution": "node"
   },
-  "include": ["src", "scripts", ".eslintrc.js", "jest.config.js"]
+  "include": ["src", "config", "scripts", ".eslintrc.js", "jest.config.js"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => ({
   entry: [
+    'src/filePaths.ts',
     'src/preset.ts',
     'src/preview.ts',
     'src/bin/archive-storybook.ts',


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->
Raise an error when the archives dir cannot be found, which can happen if the e2e tests have not been run, or if there is a misconfiguration.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Install the canary version in a test e2e project
* Remove the `test-results` dir
* Run `archive-storybook`
* See an error message about not finding the dir

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
