### PR TITLE
:lipstick: Add an id to the inner iframe element used for E2E tests.

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -23,6 +23,7 @@ function updateDimensions(iframe: HTMLIFrameElement) {
     'style',
     `${iframeStyle}; width: ${scrollWidth}px; height: ${scrollHeight}px;`
   );
+  iframe.setAttribute('id', 'chromatic-e2e-inner-iframe');
 }
 
 const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context, element) => {


### PR DESCRIPTION
As part of CAP-1291, we need to have a unique identifier for this inner iframe. This adds said identifier.

Issue: CAP-1291

## What Changed

Added an id to the inner iframe element.

## How to test

Open an E2E test storybook and verify that the inner iframe has an id on it.

## Change Type

- [x] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.18--canary.13.67923b4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/archive-storybook@0.0.18--canary.13.67923b4.0
  # or 
  yarn add @chromaui/archive-storybook@0.0.18--canary.13.67923b4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
