### PR TITLE
Instead of creating an iframe, just render the html part of the snapshot

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -31,20 +31,31 @@ const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context, element) 
   const response = await fetch(`${url}/${id}`);
   const snapshot = await response.json();
 
+  // The snapshot is a representation of a complete HTML document. The first child is the
+  // doc type declaration and the second is the html element.
   const htmlNode = snapshot.childNodes[1];
 
+  // If you rebuild the full snapshot with rrweb (the document) it will replace the
+  // current document and call `document.open()` in the process, which unbinds all event handlers
+  // (and breaks Storybook).
+  // However, if you just rebuild the html element part, it will recreate but not attempt to
+  // insert it in the DOM.
   // @ts-expect-error rebuild is typed incorreclty, cache and mirror are optional
   const html = (await rebuild(htmlNode, { doc: document })) as HTMLElement;
 
-  document.children[0].innerHTML = html.innerHTML;
+  // Now we insert the rebuilt html element in the DOM
+  document.replaceChild(html, document.children[0]);
 
-  // insert a couple of elements to fool SB
-  document.body.innerHTML += '<div id="storybook-root"></div><div id="storybook-docs"></div>';
+  // Storybook's WebView will throw an error if it cannot find these two ids in the DOM.
+  // We never render docs (so the #storybook-docs doesn't matter), and our`renderToCanvas`
+  // function is already ignoring the #storybook-root (`element` above), so it doesn't matter where
+  // they are or what they contain.
+  // We make them a script in the head to ensure they don't impact layout.
+  document.head.innerHTML +=
+    '<script id="storybook-root"></script><script id="storybook-docs"></script>';
 
   context.showMain();
-  return () => {
-    // element.removeChild(iframe);
-  };
+  return () => {}; // We can't really cleanup
 };
 
 export { renderToCanvas };

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -31,25 +31,19 @@ const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context, element) 
   const response = await fetch(`${url}/${id}`);
   const snapshot = await response.json();
 
-  const iframe = document.createElement('iframe');
-  iframe.setAttribute('style', iframeStyle);
-  element.appendChild(iframe);
+  const htmlNode = snapshot.childNodes[1];
 
   // @ts-expect-error rebuild is typed incorreclty, cache and mirror are optional
-  await rebuild(snapshot, { doc: iframe.contentDocument });
+  const html = (await rebuild(htmlNode, { doc: document })) as HTMLElement;
 
-  // Wait a moment, then set the dimensions of the iframe
-  setTimeout(() => updateDimensions(iframe), 100);
+  document.children[0].innerHTML = html.innerHTML;
 
-  // Also update the dimension every time the window changes size
-  window.addEventListener(
-    'resize',
-    debounce(() => updateDimensions(iframe), 100)
-  );
+  // insert a couple of elements to fool SB
+  document.body.innerHTML += '<div id="storybook-root"></div><div id="storybook-docs"></div>';
 
   context.showMain();
   return () => {
-    element.removeChild(iframe);
+    // element.removeChild(iframe);
   };
 };
 


### PR DESCRIPTION
Fixes AP-3900

## What Changed

Previously, we created an iframe to render the full document snapshot, as `rrweb` requires re-`open()`-ing the document (and dropping all event handlers, including the ones the preview uses).

Instead, we can use `rrweb` to just render the `html` element part of the document and do an `innerHTML` replacement of the result. This seems to work fine.

The only thing we need to do is a minor hack to ensure `#storybook-root` and `#storybook-docs` are always available, as the `WebView` assumes they are there and errors if they are not.

@shilman - perhaps we can either make the `WebView` more resilient, or even allow overriding the web view from a preset somehow (that might be tricky).

## How to test

Include this canary in a project, check that you can render stories and run Chromatic builds.

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.19--canary.14.df1452d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/archive-storybook@0.0.19--canary.14.df1452d.0
  # or 
  yarn add @chromaui/archive-storybook@0.0.19--canary.14.df1452d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
